### PR TITLE
Return enums instead of strings when accessing the relation data

### DIFF
--- a/lib/charms/smtp_integrator/v0/smtp.py
+++ b/lib/charms/smtp_integrator/v0/smtp.py
@@ -58,7 +58,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 # pylint: disable=wrong-import-position
 import logging
@@ -193,16 +193,16 @@ class SmtpDataAvailableEvent(ops.RelationEvent):
         return self.relation.data[self.relation.app].get("password_id")
 
     @property
-    def auth_type(self) -> str:
+    def auth_type(self) -> AuthType:
         """Fetch the SMTP auth type from the relation."""
         assert self.relation.app
-        return self.relation.data[self.relation.app].get("auth_type")
+        return AuthType(self.relation.data[self.relation.app].get("auth_type"))
 
     @property
-    def transport_security(self) -> str:
+    def transport_security(self) -> TransportSecurity:
         """Fetch the SMTP transport security protocol from the relation."""
         assert self.relation.app
-        return self.relation.data[self.relation.app].get("transport_security")
+        return TransportSecurity(self.relation.data[self.relation.app].get("transport_security"))
 
     @property
     def domain(self) -> str:


### PR DESCRIPTION
Applicable spec: N/A

### Overview

<!-- A high level overview of the change -->
Return enums instead of strings when accessing the relation data

### Rationale

<!-- The reason the change is needed -->
Dev experience improvements

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
N/A

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
N/A

### Library Changes

<!-- Any changes to charm libraries -->
smtp lib API

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
