### PR TITLE
Use python3.8 syntax in the smtp library

### DIFF
--- a/lib/charms/smtp_integrator/v0/smtp.py
+++ b/lib/charms/smtp_integrator/v0/smtp.py
@@ -58,12 +58,12 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 # pylint: disable=wrong-import-position
 import logging
 from enum import Enum
-from typing import Optional
+from typing import Dict, Optional
 
 import ops
 from pydantic import BaseModel, Field, ValidationError
@@ -125,7 +125,7 @@ class SmtpRelationData(BaseModel):
     transport_security: TransportSecurity
     domain: Optional[str]
 
-    def to_relation_data(self) -> dict[str, str]:
+    def to_relation_data(self) -> Dict[str, str]:
         """Convert an instance of SmtpRelationData to the relation representation.
 
         Returns:

--- a/lib/charms/smtp_integrator/v0/smtp.py
+++ b/lib/charms/smtp_integrator/v0/smtp.py
@@ -63,7 +63,7 @@ LIBPATCH = 2
 # pylint: disable=wrong-import-position
 import logging
 from enum import Enum
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 import ops
 from pydantic import BaseModel, Field, ValidationError
@@ -306,7 +306,7 @@ class SmtpProvides(ops.Object):
         self.relation_name = relation_name
 
     @property
-    def relations(self) -> list[ops.Relation]:
+    def relations(self) -> List[ops.Relation]:
         """The list of Relation instances associated with this relation_name.
 
         Returns:


### PR DESCRIPTION
Applicable spec: N/A

### Overview

<!-- A high level overview of the change -->
Use python3.8 syntax in the library

### Rationale

<!-- The reason the change is needed -->
Use python3.8 syntax so that the library code can be run on ubuntu 20

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
N/A

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
N/A

### Library Changes

<!-- Any changes to charm libraries -->
N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
