### PR TITLE
Add method in the smtp library to retrieve the relation data directly

### DIFF
--- a/lib/charms/smtp_integrator/v0/smtp.py
+++ b/lib/charms/smtp_integrator/v0/smtp.py
@@ -58,7 +58,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 # pylint: disable=wrong-import-position
 import logging
@@ -244,6 +244,38 @@ class SmtpRequires(ops.Object):
         self.relation_name = relation_name
         self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
 
+    def get_relation_data(self) -> SmtpRelationData:
+        """Retrieve the relation data.
+
+        Returns:
+            SmtpRelationData: the relation data.
+        """
+        relation = self.model.get_relation(self.relation_name)
+        assert relation
+        return self._get_relation_data_from_relation(relation)
+
+    def _get_relation_data_from_relation(self, relation: ops.Relation) -> SmtpRelationData:
+        """Retrieve the relation data.
+
+        Args:
+            relation: the relation to retrieve the data from.
+
+        Returns:
+            SmtpRelationData: the relation data.
+        """
+        assert relation.app
+        relation_data = relation.data[relation.app]
+        return SmtpRelationData(
+            host=relation_data.get("host"),
+            port=relation_data.get("port"),
+            user=relation_data.get("user"),
+            password=relation_data.get("password"),
+            password_id=relation_data.get("password_id"),
+            auth_type=relation_data.get("auth_type"),
+            transport_security=relation_data.get("transport_security"),
+            domain=relation_data.get("domain"),
+        )
+
     def _is_relation_data_valid(self, relation: ops.Relation) -> bool:
         """Validate the relation data.
 
@@ -254,18 +286,7 @@ class SmtpRequires(ops.Object):
             true: if the relation data is valid.
         """
         try:
-            assert relation.app
-            relation_data = relation.data[relation.app]
-            _ = SmtpRelationData(
-                host=relation_data.get("host"),
-                port=relation_data.get("port"),
-                user=relation_data.get("user"),
-                password=relation_data.get("password"),
-                password_id=relation_data.get("password_id"),
-                auth_type=relation_data.get("auth_type"),
-                transport_security=relation_data.get("transport_security"),
-                domain=relation_data.get("domain"),
-            )
+            _ = self._get_relation_data_from_relation(relation)
             return True
         except ValidationError:
             return False

--- a/lib/charms/smtp_integrator/v0/smtp.py
+++ b/lib/charms/smtp_integrator/v0/smtp.py
@@ -244,7 +244,7 @@ class SmtpRequires(ops.Object):
         self.relation_name = relation_name
         self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
 
-    def get_relation_data(self) -> SmtpRelationData:
+    def get_relation_data(self) -> Optional[SmtpRelationData]:
         """Retrieve the relation data.
 
         Returns:
@@ -252,7 +252,7 @@ class SmtpRequires(ops.Object):
         """
         relation = self.model.get_relation(self.relation_name)
         assert relation
-        return self._get_relation_data_from_relation(relation)
+        return self._get_relation_data_from_relation(relation) if relation else None
 
     def _get_relation_data_from_relation(self, relation: ops.Relation) -> SmtpRelationData:
         """Retrieve the relation data.

--- a/tests/unit/test_library_smtp.py
+++ b/tests/unit/test_library_smtp.py
@@ -175,6 +175,15 @@ def test_legacy_requirer_charm_with_valid_relation_data_emits_event(is_leader):
     assert harness.charm.events[0].transport_security == relation_data["transport_security"]
     assert harness.charm.events[0].domain == relation_data["domain"]
 
+    retrieved_relation_data = harness.charm.smtp_legacy.get_relation_data()
+    assert retrieved_relation_data.host == relation_data["host"]
+    assert retrieved_relation_data.port == int(relation_data["port"])
+    assert retrieved_relation_data.user == relation_data["user"]
+    assert retrieved_relation_data.password == relation_data["password"]
+    assert retrieved_relation_data.auth_type == relation_data["auth_type"]
+    assert retrieved_relation_data.transport_security == relation_data["transport_security"]
+    assert retrieved_relation_data.domain == relation_data["domain"]
+
 
 @pytest.mark.parametrize("is_leader", [True, False])
 def test_requirer_charm_with_valid_relation_data_emits_event(is_leader):


### PR DESCRIPTION
Applicable spec: N/A

### Overview

<!-- A high level overview of the change -->
Add method in the smtp library to retrieve the relation data directly

### Rationale

<!-- The reason the change is needed -->
Improve dev experience for requirer charms

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
N/A

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
smtp lib

### Library Changes

<!-- Any changes to charm libraries -->
Add the new method

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
