### PR TITLE
Fix inline docs and rename method names

### DIFF
--- a/docs/explanation/charm-architecture.md
+++ b/docs/explanation/charm-architecture.md
@@ -10,8 +10,8 @@ For this charm, the following events are observed:
 
 1. [config-changed](https://juju.is/docs/sdk/config-changed-event): usually fired in response to a configuration change using the GUI or CLI. Action: validate the configuration and propagate the SMTP configuration through the relation.
 2. [update-status](https://juju.is/docs/sdk/update-status-event): fired periodically. Action: propagate the SMTP configuration through the relation.
-3. [smtp-relation-joined](https://juju.is/docs/sdk/relation-name-relation-joined-event): Custom event for when a new SMTP relations joins. Action: write the SMTP details in the relation databag. The `saml` integration will share a secret id across the relation the requirer will be able to access to retrieve the password.
-4. [smtp-legacy-relation-joined](https://juju.is/docs/sdk/relation-name-relation-joined-event): Custom event for when a new legacy SMTP relations joins. Action: write the SMTP details in the relation databag. The `saml-legacy` integration will share the password across the relation.
+3. [smtp-relation-joined](https://juju.is/docs/sdk/relation-name-relation-joined-event): Custom event for when a new SMTP relations joins. Action: write the SMTP details in the relation databag. The `smtp` integration will share a secret id across the relation the requirer will be able to access to retrieve the password.
+4. [smtp-legacy-relation-joined](https://juju.is/docs/sdk/relation-name-relation-joined-event): Custom event for when a new legacy SMTP relations joins. Action: write the SMTP details in the relation databag. The `smtp-legacy` integration will share the password across the relation.
 
 ## Charm code overview
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,6 @@ fixes and constructive feedback.
 * [Code of conduct](https://ubuntu.com/community/code-of-conduct)
 * [Get support](https://discourse.charmhub.io/)
 * [Join our online chat](https://chat.charmhub.io/charmhub/channels/charm-dev)
-* [Contribute](https://charmhub.io/saml-integrator/docs/how-to-contribute)
+* [Contribute](https://charmhub.io/smtp-integrator/docs/how-to-contribute)
 Thinking about using the SAML Integrator Operator for your next project? [Get in touch](https://chat.charmhub.io/charmhub/channels/charm-dev)!
 

--- a/lib/charms/smtp_integrator/v0/smtp.py
+++ b/lib/charms/smtp_integrator/v0/smtp.py
@@ -14,7 +14,7 @@ be shared via the integration.
 
 ```python
 
-from charms.smtp_integrator.v0 import SmtpDataAvailableEvent, SmtpRequires
+from charms.smtp_integrator.v0.smtp import SmtpDataAvailableEvent, SmtpRequires
 
 class SmtpRequirerCharm(ops.CharmBase):
     def __init__(self, *args):
@@ -36,7 +36,7 @@ which new SMTP data has been added or updated.
 Following the previous example, this is an example of the provider charm.
 
 ```python
-from charms.smtp_integrator.v0 import SmtpDataAvailableEvent, SmtpProvides
+from charms.smtp_integrator.v0.smtp import SmtpProvides
 
 class SmtpProviderCharm(ops.CharmBase):
     def __init__(self, *args):

--- a/src/charm.py
+++ b/src/charm.py
@@ -53,7 +53,7 @@ class SmtpIntegratorOperatorCharm(ops.CharmBase):
         if secret_id := self._charm_state.password_id:
             secret = self.model.get_secret(id=secret_id)
             secret.grant(event.relation)
-        self._update_saml_relation(event.relation)
+        self._update_smtp_relation(event.relation)
 
     def _on_legacy_relation_created(self, event: ops.RelationCreatedEvent) -> None:
         """Handle a change to the smtp-legacy relation.
@@ -63,7 +63,7 @@ class SmtpIntegratorOperatorCharm(ops.CharmBase):
         """
         if not self.model.unit.is_leader():
             return
-        self._update_saml_legacy_relation(event.relation)
+        self._update_smtp_legacy_relation(event.relation)
 
     def _on_config_changed(self, _) -> None:
         """Handle changes in configuration."""
@@ -84,12 +84,12 @@ class SmtpIntegratorOperatorCharm(ops.CharmBase):
         if not self.model.unit.is_leader():
             return
         for relation in self.smtp.relations:
-            self._update_saml_relation(relation)
+            self._update_smtp_relation(relation)
         for relation in self.smtp_legacy.relations:
-            self._update_saml_legacy_relation(relation)
+            self._update_smtp_legacy_relation(relation)
 
-    def _update_saml_relation(self, relation: ops.Relation) -> None:
-        """Update the saml relation databag.
+    def _update_smtp_relation(self, relation: ops.Relation) -> None:
+        """Update the smtp relation databag.
 
         Args:
             relation: the relation for which to update the databag.
@@ -97,8 +97,8 @@ class SmtpIntegratorOperatorCharm(ops.CharmBase):
         if self._has_secrets():
             self.smtp.update_relation_data(relation, self._get_smtp_data())
 
-    def _update_saml_legacy_relation(self, relation: ops.Relation) -> None:
-        """Update the saml-legacy relation databag.
+    def _update_smtp_legacy_relation(self, relation: ops.Relation) -> None:
+        """Update the smtp-legacy relation databag.
 
         Args:
             relation: the relation for which to update the databag.


### PR DESCRIPTION
Applicable spec: N/A
### Overview

<!-- A high level overview of the change -->
Fix inline docs and rename method names

### Rationale

<!-- The reason the change is needed -->
N/A

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
N/A

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
N/A

### Library Changes

<!-- Any changes to charm libraries -->
N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
