### PR TITLE
Refactor smtp provider lib

### DIFF
--- a/lib/charms/smtp_integrator/v0/smtp.py
+++ b/lib/charms/smtp_integrator/v0/smtp.py
@@ -58,13 +58,13 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 # pylint: disable=wrong-import-position
 import itertools
 import logging
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 
 import ops
 from pydantic import BaseModel, Field, ValidationError
@@ -314,11 +314,7 @@ class SmtpRequires(ops.Object):
 
 
 class SmtpProvides(ops.Object):
-    """Provider side of the SMTP relation.
-
-    Attributes:
-        relations: list of charm relations.
-    """
+    """Provider side of the SMTP relation."""
 
     def __init__(self, charm: ops.CharmBase, relation_name: str = DEFAULT_RELATION_NAME) -> None:
         """Construct.
@@ -330,15 +326,6 @@ class SmtpProvides(ops.Object):
         super().__init__(charm, relation_name)
         self.charm = charm
         self.relation_name = relation_name
-
-    @property
-    def relations(self) -> List[ops.Relation]:
-        """The list of Relation instances associated with this relation_name.
-
-        Returns:
-            List of relations to this charm.
-        """
-        return list(self.model.relations[self.relation_name])
 
     def update_relation_data(self, relation: ops.Relation, smtp_data: SmtpRelationData) -> None:
         """Update the relation data.

--- a/lib/charms/smtp_integrator/v0/smtp.py
+++ b/lib/charms/smtp_integrator/v0/smtp.py
@@ -48,6 +48,16 @@ class SmtpProviderCharm(ops.CharmBase):
 The SmtpProvides object wraps the list of relations into a `relations` property
 and provides an `update_relation_data` method to update the relation data by passing
 a `SmtpRelationData` data object.
+
+```python
+class SmtpProviderCharm(ops.CharmBase):
+    ...
+
+    def _on_config_changed(self, _) -> None:
+        for relation in self.model.relations[self.smtp.relation_name]:
+            self.smtp.update_relation_data(relation, self._get_smtp_data())
+
+```
 """
 
 # The unique Charmhub library identifier, never change it

--- a/src/charm.py
+++ b/src/charm.py
@@ -83,9 +83,9 @@ class SmtpIntegratorOperatorCharm(ops.CharmBase):
         """Update all SMTP data for the existing relations."""
         if not self.model.unit.is_leader():
             return
-        for relation in self.smtp.relations:
+        for relation in self.model.relations[self.smtp.relation_name]:
             self._update_smtp_relation(relation)
-        for relation in self.smtp_legacy.relations:
+        for relation in self.model.relations[self.smtp_legacy.relation_name]:
             self._update_smtp_legacy_relation(relation)
 
     def _update_smtp_relation(self, relation: ops.Relation) -> None:

--- a/tests/unit/test_library_smtp.py
+++ b/tests/unit/test_library_smtp.py
@@ -96,20 +96,6 @@ class SmtpProviderCharm(ops.CharmBase):
         self.events.append(event)
 
 
-def test_smtp_provider_charm_relations():
-    """
-    arrange: instantiate a SmtpProviderCharm and add an smtp-legacy relation.
-    act: obtain the relations.
-    assert: the relations retrieved match the existing relations.
-    """
-    harness = Harness(SmtpProviderCharm, meta=PROVIDER_METADATA)
-    harness.begin()
-    harness.set_leader(True)
-    harness.add_relation("smtp-legacy", "smtp-provider")
-    assert len(harness.charm.smtp_legacy.relations) == 1
-    assert len(harness.charm.smtp.relations) == 0
-
-
 def test_smtp_provider_update_relation_data():
     """
     arrange: instantiate a SmtpProviderCharm object and add an smtp-legacy relation.


### PR DESCRIPTION
Applicable spec: N/A
### Overview

<!-- A high level overview of the change -->
Refactor smtp provider lib

### Rationale

<!-- The reason the change is needed -->
Remove from the SmtpProvider an attribute that conceptually belongs to the charm itself

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
N/A

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
charm.py adapted to the lib changes

### Library Changes

<!-- Any changes to charm libraries -->
Removed the SmtpProvider relation property

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
