### PR TITLE
Log a warning when the configuration of the provider is unsafe

### DIFF
--- a/lib/charms/smtp_integrator/v0/smtp.py
+++ b/lib/charms/smtp_integrator/v0/smtp.py
@@ -68,7 +68,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 # pylint: disable=wrong-import-position
 import itertools
@@ -344,4 +344,9 @@ class SmtpProvides(ops.Object):
             relation: the relation for which to update the data.
             smtp_data: a SmtpRelationData instance wrapping the data to be updated.
         """
-        relation.data[self.charm.model.app].update(smtp_data.to_relation_data())
+        relation_data = smtp_data.to_relation_data()
+        if relation_data["auth_type"] == AuthType.NONE.value:
+            logger.warning('Insecure setting: auth_type has a value "none"')
+        if relation_data["transport_security"] == TransportSecurity.NONE.value:
+            logger.warning('Insecure setting: transport_security has value "none"')
+        relation.data[self.charm.model.app].update(relation_data)


### PR DESCRIPTION
Applicable spec: N/A

### Overview

<!-- A high level overview of the change -->
Log a warning when the configuration of the provider is unsafe

### Rationale

<!-- The reason the change is needed -->
N/A

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
N/A

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
N/A

### Library Changes

<!-- Any changes to charm libraries -->
smtp lib

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
