### PR TITLE
Add PYDEPS to the `charms.smtp_integrator.v0.smtp` charm library and upgrade pydantic to v2

### DIFF
--- a/lib/charms/smtp_integrator/v0/smtp.py
+++ b/lib/charms/smtp_integrator/v0/smtp.py
@@ -68,7 +68,9 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
+
+PYDEPS = ["pydantic>=2"]
 
 # pylint: disable=wrong-import-position
 import itertools
@@ -129,12 +131,12 @@ class SmtpRelationData(BaseModel):
 
     host: str = Field(..., min_length=1)
     port: int = Field(None, ge=1, le=65536)
-    user: Optional[str]
-    password: Optional[str]
-    password_id: Optional[str]
+    user: Optional[str] = None
+    password: Optional[str] = None
+    password_id: Optional[str] = None
     auth_type: AuthType
     transport_security: TransportSecurity
-    domain: Optional[str]
+    domain: Optional[str] = None
 
     def to_relation_data(self) -> Dict[str, str]:
         """Convert an instance of SmtpRelationData to the relation representation.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 ops==2.10.0
-pydantic==1.10.14
+pydantic==2.6.1

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -29,11 +29,11 @@ class SmtpIntegratorConfig(BaseModel):
 
     host: str = Field(..., min_length=1)
     port: int = Field(None, ge=1, le=65536)
-    user: Optional[str]
-    password: Optional[str]
-    auth_type: Optional[smtp.AuthType]
-    transport_security: Optional[smtp.TransportSecurity]
-    domain: Optional[str]
+    user: Optional[str] = None
+    password: Optional[str] = None
+    auth_type: smtp.AuthType | None = None
+    transport_security: smtp.TransportSecurity | None = None
+    domain: Optional[str] = None
 
 
 class CharmConfigInvalidError(Exception):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -53,6 +53,7 @@ async def any_charm(ops_test: OpsTest):
         "any-charm",
         application_name="any",
         channel="beta",
-        config={"src-overwrite": json.dumps(src_overwrite)},
+        # Sync the python-packages here with smtp charm lib PYDEPS
+        config={"src-overwrite": json.dumps(src_overwrite), "python-packages": "pydantic>=2"},
     )
     yield application


### PR DESCRIPTION
### Overview

As the `charms.smtp_integrator.v0.smtp` charm library depends on `pydantic` to function, it needs to declare the [`PYDEPS` key in the charm library](https://discourse.charmhub.io/t/python-dependencies-in-charm-libraries/8599). Additionally, upgrade the `pydantic` version to `v2`. If there is any reason to continue using `pydantic` v1, please let me know, and I will revert the upgrade.

Also, update the integration test. With [the newer version of `any-charm`](https://github.com/canonical/any-charm/pull/11), it will no longer include any pre-installed Python dependencies. All Python dependencies must be installed via `any-charm`'s `python-packages` charm configurations. Some commonly used Python packages, like `pydantic`, are pre-packed with `any-charm`, allowing installation to be done locally.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
