### PR TITLE
Add `skip_ssl_verify` flag for certificate trust verification

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -8,3 +8,14 @@ bases:
     run-on:
     - name: ubuntu
       channel: "22.04"
+parts:
+  charm:
+    override-build: |
+      rustup default stable
+      craftctl default
+    build-snaps:
+      - rustup
+    build-packages:
+      - libffi-dev
+      - libssl-dev
+      - pkg-config

--- a/config.yaml
+++ b/config.yaml
@@ -26,3 +26,7 @@ options:
   domain:
     description: The domain used by the sent emails from SMTP relay
     type: string
+  skip_ssl_verify:
+    description: Specifies if certificate trust verification is skipped in the SMTP relay
+    type: boolean
+    default: false

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -15,7 +15,7 @@ SMTP Integrator Charm service.
 ## <kbd>class</kbd> `SmtpIntegratorOperatorCharm`
 Charm the service. 
 
-<a href="../src/charm.py#L24"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L25"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src-docs/charm_state.py.md
+++ b/src-docs/charm_state.py.md
@@ -18,7 +18,7 @@ Exception raised when a charm configuration is found to be invalid.
  
  - <b>`msg`</b> (str):  Explanation of the error. 
 
-<a href="../src/charm_state.py#L46"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L48"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -53,9 +53,10 @@ Represents the state of the SMTP Integrator charm.
  - <b>`password`</b>:  The SMTP AUTH password to use for the outgoing SMTP relay. 
  - <b>`auth_type`</b>:  The type used to authenticate with the SMTP relay. 
  - <b>`transport_security`</b>:  The security protocol to use for the outgoing SMTP relay. 
- - <b>`domain`</b>:  The domain used by the sent emails from SMTP relay. 
+ - <b>`domain`</b>:  The domain used by the emails sent from SMTP relay. 
+ - <b>`skip_ssl_verify`</b>:  Specifies if certificate trust verification is skipped in the SMTP relay. 
 
-<a href="../src/charm_state.py#L77"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L81"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -76,7 +77,7 @@ Initialize a new instance of the CharmState class.
 
 ---
 
-<a href="../src/charm_state.py#L91"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L96"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -116,8 +117,31 @@ Represent charm builtin configuration values.
  - <b>`password`</b>:  The SMTP AUTH password to use for the outgoing SMTP relay. 
  - <b>`auth_type`</b>:  The type used to authenticate with the SMTP relay. 
  - <b>`transport_security`</b>:  The security protocol to use for the outgoing SMTP relay. 
- - <b>`domain`</b>:  The domain used by the sent emails from SMTP relay. 
+ - <b>`domain`</b>:  The domain used by the emails sent from SMTP relay. 
+ - <b>`skip_ssl_verify`</b>:  Specifies if certificate trust verification is skipped in the SMTP relay. 
 
+
+---
+
+#### <kbd>property</kbd> model_extra
+
+Get extra fields set during validation. 
+
+
+
+**Returns:**
+  A dictionary of extra fields, or `None` if `config.extra` is not set to `"allow"`. 
+
+---
+
+#### <kbd>property</kbd> model_fields_set
+
+Returns the set of fields that have been explicitly set on this model instance. 
+
+
+
+**Returns:**
+  A set of strings representing the fields that have been set,  i.e. that were not filled from defaults. 
 
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -143,6 +143,7 @@ class SmtpIntegratorOperatorCharm(ops.CharmBase):
             auth_type=self._charm_state.auth_type,
             transport_security=self._charm_state.transport_security,
             domain=self._charm_state.domain,
+            skip_ssl_verify=self._charm_state.skip_ssl_verify,
         )
 
     def _get_smtp_data(self) -> smtp.SmtpRelationData:
@@ -162,6 +163,7 @@ class SmtpIntegratorOperatorCharm(ops.CharmBase):
             auth_type=self._charm_state.auth_type,
             transport_security=self._charm_state.transport_security,
             domain=self._charm_state.domain,
+            skip_ssl_verify=self._charm_state.skip_ssl_verify,
         )
 
     def _has_secrets(self) -> bool:

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -24,7 +24,8 @@ class SmtpIntegratorConfig(BaseModel):
         password: The SMTP AUTH password to use for the outgoing SMTP relay.
         auth_type: The type used to authenticate with the SMTP relay.
         transport_security: The security protocol to use for the outgoing SMTP relay.
-        domain: The domain used by the sent emails from SMTP relay.
+        domain: The domain used by the emails sent from SMTP relay.
+        skip_ssl_verify: Specifies if certificate trust verification is skipped in the SMTP relay.
     """
 
     host: str = Field(..., min_length=1)
@@ -34,6 +35,7 @@ class SmtpIntegratorConfig(BaseModel):
     auth_type: smtp.AuthType | None = None
     transport_security: smtp.TransportSecurity | None = None
     domain: Optional[str] = None
+    skip_ssl_verify: bool = False
 
 
 class CharmConfigInvalidError(Exception):
@@ -63,7 +65,8 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
         password: The SMTP AUTH password to use for the outgoing SMTP relay.
         auth_type: The type used to authenticate with the SMTP relay.
         transport_security: The security protocol to use for the outgoing SMTP relay.
-        domain: The domain used by the sent emails from SMTP relay.
+        domain: The domain used by the emails sent from SMTP relay.
+        skip_ssl_verify: Specifies if certificate trust verification is skipped in the SMTP relay.
     """
 
     host: str
@@ -73,6 +76,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
     auth_type: Optional[smtp.AuthType]
     transport_security: Optional[smtp.TransportSecurity]
     domain: Optional[str]
+    skip_ssl_verify: bool
 
     def __init__(self, *, smtp_integrator_config: SmtpIntegratorConfig):
         """Initialize a new instance of the CharmState class.
@@ -87,6 +91,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
         self.auth_type = smtp_integrator_config.auth_type
         self.transport_security = smtp_integrator_config.transport_security
         self.domain = smtp_integrator_config.domain
+        self.skip_ssl_verify = smtp_integrator_config.skip_ssl_verify
 
     @classmethod
     def from_charm(cls, charm: "ops.CharmBase") -> "CharmState":

--- a/tests/unit/test_library_smtp.py
+++ b/tests/unit/test_library_smtp.py
@@ -3,6 +3,7 @@
 
 """SMTP library unit tests"""
 import secrets
+from ast import literal_eval
 
 import ops
 import pytest
@@ -34,6 +35,7 @@ RELATION_DATA = {
     "auth_type": "plain",
     "transport_security": "tls",
     "domain": "domain",
+    "skip_ssl_verify": "False",
 }
 
 SAMPLE_LEGACY_RELATION_DATA = {
@@ -112,6 +114,7 @@ def test_smtp_provider_update_relation_data():
         port=25,
         auth_type="plain",
         transport_security="tls",
+        skip_ssl_verify=False,
     )
     harness.charm.smtp_legacy.update_relation_data(relation, smtp_data)
     data = relation.data[harness.model.app]
@@ -119,6 +122,7 @@ def test_smtp_provider_update_relation_data():
     assert data["port"] == str(smtp_data.port)
     assert data["auth_type"] == smtp_data.auth_type
     assert data["transport_security"] == smtp_data.transport_security
+    assert data["skip_ssl_verify"] == str(smtp_data.skip_ssl_verify)
 
 
 def test_smtp_relation_data_to_relation_data():
@@ -136,6 +140,7 @@ def test_smtp_relation_data_to_relation_data():
         auth_type="plain",
         transport_security="tls",
         domain="domain",
+        skip_ssl_verify=False,
     )
     relation_data = smtp_data.to_relation_data()
     expected_relation_data = {
@@ -147,6 +152,7 @@ def test_smtp_relation_data_to_relation_data():
         "auth_type": "plain",
         "transport_security": "tls",
         "domain": "domain",
+        "skip_ssl_verify": "False",
     }
     assert relation_data == expected_relation_data
 
@@ -204,6 +210,9 @@ def test_legacy_requirer_charm_with_valid_relation_data_emits_event(is_leader):
         == SAMPLE_LEGACY_RELATION_DATA["transport_security"]
     )
     assert harness.charm.events[0].domain == SAMPLE_LEGACY_RELATION_DATA["domain"]
+    assert harness.charm.events[0].skip_ssl_verify == literal_eval(
+        SAMPLE_LEGACY_RELATION_DATA["skip_ssl_verify"]
+    )
 
     retrieved_relation_data = harness.charm.smtp_legacy.get_relation_data()
     assert retrieved_relation_data.host == SAMPLE_LEGACY_RELATION_DATA["host"]
@@ -216,6 +225,9 @@ def test_legacy_requirer_charm_with_valid_relation_data_emits_event(is_leader):
         == SAMPLE_LEGACY_RELATION_DATA["transport_security"]
     )
     assert retrieved_relation_data.domain == SAMPLE_LEGACY_RELATION_DATA["domain"]
+    assert retrieved_relation_data.skip_ssl_verify == literal_eval(
+        SAMPLE_LEGACY_RELATION_DATA["skip_ssl_verify"]
+    )
 
 
 @pytest.mark.parametrize("is_leader", [True, False])
@@ -238,6 +250,9 @@ def test_requirer_charm_with_valid_relation_data_emits_event(is_leader):
     assert harness.charm.events[0].auth_type == SAMPLE_RELATION_DATA["auth_type"]
     assert harness.charm.events[0].transport_security == SAMPLE_RELATION_DATA["transport_security"]
     assert harness.charm.events[0].domain == SAMPLE_RELATION_DATA["domain"]
+    assert harness.charm.events[0].skip_ssl_verify == literal_eval(
+        SAMPLE_RELATION_DATA["skip_ssl_verify"]
+    )
 
 
 @pytest.mark.parametrize("is_leader", [True, False])
@@ -254,6 +269,7 @@ def test_requirer_charm_with_invalid_relation_data_doesnt_emit_event(is_leader):
         "auth_type": "plain",
         "transport_security": "tls",
         "domain": "domain",
+        "skip_ssl_verify": "False",
     }
 
     harness = Harness(SmtpRequirerCharm, meta=REQUIRER_METADATA)


### PR DESCRIPTION
Applicable spec: n/a

### Overview

<!-- A high level overview of the change -->
This PR adds `skip_ssl_verify` as a new config option and `smtp` lib parameter.

### Rationale

<!-- The reason the change is needed -->
Some requirers of the smtp library need additional parameters for smtp configuration. One of them is `skip_ssl_verify`, which  specifies if certificate trust verification is skipped in the integrated SMTP relay. This is a common config option which disables SSL verification, e.g. allowing the use of self-signed certificates.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
n/a

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
n/a
### Library Changes

<!-- Any changes to charm libraries -->
- added `skip_ssl_verify` flag
### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
Can't add the trivial label as a non-maintainer