### PR TITLE
Handle the situation when there's no data in relation

### DIFF
--- a/lib/charms/smtp_integrator/v0/smtp.py
+++ b/lib/charms/smtp_integrator/v0/smtp.py
@@ -68,7 +68,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 11
+LIBPATCH = 12
 
 PYDEPS = ["pydantic>=2"]
 
@@ -280,7 +280,7 @@ class SmtpRequires(ops.Object):
         relation = self.model.get_relation(self.relation_name)
         return self._get_relation_data_from_relation(relation) if relation else None
 
-    def _get_relation_data_from_relation(self, relation: ops.Relation) -> SmtpRelationData:
+    def _get_relation_data_from_relation(self, relation: ops.Relation) -> SmtpRelationData | None:
         """Retrieve the relation data.
 
         Args:
@@ -291,6 +291,8 @@ class SmtpRequires(ops.Object):
         """
         assert relation.app
         relation_data = relation.data[relation.app]
+        if not relation_data:
+            return None
         return SmtpRelationData(
             host=typing.cast(str, relation_data.get("host")),
             port=typing.cast(int, relation_data.get("port")),

--- a/tests/unit/test_library_smtp.py
+++ b/tests/unit/test_library_smtp.py
@@ -278,3 +278,16 @@ def test_requirer_charm_with_invalid_relation_data_doesnt_emit_event(is_leader):
     harness.add_relation("smtp-legacy", "smtp-provider", app_data=relation_data)
 
     assert len(harness.charm.events) == 0
+
+
+def test_requirer_charm_get_relation_data_without_relation_data():
+    """
+    arrange: set up a charm with smtp relation without any relation data.
+    act: call get_relation_data function.
+    assert: get_relation_data should return None.
+    """
+    harness = Harness(SmtpRequirerCharm, meta=REQUIRER_METADATA)
+    harness.begin()
+    harness.set_leader(True)
+    harness.add_relation("smtp", "smtp-provider", app_data={})
+    assert harness.charm.smtp.get_relation_data() is None


### PR DESCRIPTION
### Overview

Handle the situation when `get_relation_data` is called in the `smtp` charm library while there is an `smtp` relation, but the smtp provider hasn't sent the smtp information in the integration. The `get_relation_data` should return `None` instead of throwing an error.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
