### PR TITLE
Make smtp charm library compatible with Python 3.8

### DIFF
--- a/lib/charms/smtp_integrator/v0/smtp.py
+++ b/lib/charms/smtp_integrator/v0/smtp.py
@@ -280,7 +280,7 @@ class SmtpRequires(ops.Object):
         relation = self.model.get_relation(self.relation_name)
         return self._get_relation_data_from_relation(relation) if relation else None
 
-    def _get_relation_data_from_relation(self, relation: ops.Relation) -> SmtpRelationData | None:
+    def _get_relation_data_from_relation(self, relation: ops.Relation) -> Optional[SmtpRelationData]:
         """Retrieve the relation data.
 
         Args:

--- a/lib/charms/smtp_integrator/v0/smtp.py
+++ b/lib/charms/smtp_integrator/v0/smtp.py
@@ -280,7 +280,9 @@ class SmtpRequires(ops.Object):
         relation = self.model.get_relation(self.relation_name)
         return self._get_relation_data_from_relation(relation) if relation else None
 
-    def _get_relation_data_from_relation(self, relation: ops.Relation) -> Optional[SmtpRelationData]:
+    def _get_relation_data_from_relation(
+        self, relation: ops.Relation
+    ) -> Optional[SmtpRelationData]:
         """Retrieve the relation data.
 
         Args:

--- a/lib/charms/smtp_integrator/v0/smtp.py
+++ b/lib/charms/smtp_integrator/v0/smtp.py
@@ -68,7 +68,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 12
+LIBPATCH = 13
 
 PYDEPS = ["pydantic>=2"]
 

--- a/tox.ini
+++ b/tox.ini
@@ -115,6 +115,7 @@ deps =
     pytest
     pytest-asyncio
     pytest-operator
+    websockets<14.0 # https://github.com/juju/python-libjuju/issues/1184
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --ignore={[vars]tst_path}interface --log-cli-level=INFO -s {posargs}
@@ -126,6 +127,7 @@ deps =
     pytest
     pytest-asyncio
     pytest-operator
+    websockets<14.0 # https://github.com/juju/python-libjuju/issues/1184
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --ignore={[vars]tst_path}interface --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Make the `smtp` charm library compatible with Python 3.8 to pass the interface test

Fix: https://github.com/canonical/charm-relation-interfaces/issues/189

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
