### PR TITLE
Feat(secret): Handle the secret password in the requirer instead of u…

### DIFF
--- a/lib/charms/smtp_integrator/v0/smtp.py
+++ b/lib/charms/smtp_integrator/v0/smtp.py
@@ -68,7 +68,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 14
+LIBPATCH = 15
 
 PYDEPS = ["pydantic>=2"]
 
@@ -295,11 +295,19 @@ class SmtpRequires(ops.Object):
         relation_data = relation.data[relation.app]
         if not relation_data:
             return None
+
+        password = relation_data.get("password")
+        if relation_data.get("password_id"):
+            password = (
+                self.model.get_secret(id=relation_data.get("password_id"))
+                .get_content()
+                .get("password")
+            )
         return SmtpRelationData(
             host=typing.cast(str, relation_data.get("host")),
             port=typing.cast(int, relation_data.get("port")),
             user=relation_data.get("user"),
-            password=relation_data.get("password"),
+            password=password,
             password_id=relation_data.get("password_id"),
             auth_type=AuthType(relation_data.get("auth_type")),
             transport_security=TransportSecurity(relation_data.get("transport_security")),

--- a/lib/charms/smtp_integrator/v0/smtp.py
+++ b/lib/charms/smtp_integrator/v0/smtp.py
@@ -297,12 +297,13 @@ class SmtpRequires(ops.Object):
             return None
 
         password = relation_data.get("password")
-        if relation_data.get("password_id"):
+        if password is None and relation_data.get("password_id"):
             password = (
                 self.model.get_secret(id=relation_data.get("password_id"))
                 .get_content()
                 .get("password")
             )
+
         return SmtpRelationData(
             host=typing.cast(str, relation_data.get("host")),
             port=typing.cast(int, relation_data.get("port")),

--- a/tests/unit/test_library_smtp.py
+++ b/tests/unit/test_library_smtp.py
@@ -42,7 +42,15 @@ SAMPLE_LEGACY_RELATION_DATA = {
     **RELATION_DATA,
     "password": secrets.token_hex(),
 }
-
+SAMPLE_RELATION_DATA = {
+    "host": "example.smtp",
+    "port": "25",
+    "user": "example_user",
+    "auth_type": "none",
+    "transport_security": "none",
+    "domain": "domain",
+    "skip_ssl_verify": "False",
+}
 
 class SmtpRequirerCharm(ops.CharmBase):
     """Class for requirer charm testing."""
@@ -239,19 +247,19 @@ def test_requirer_charm_with_valid_relation_data_emits_event(is_leader):
     password = "secret"
     secret_id = harness.add_user_secret({"password": password})
     harness.grant_secret(secret_id, "smtp-consumer")
-    RELATION_DATA["password_id"] = secret_id
-    harness.add_relation("smtp", "smtp-provider", app_data=RELATION_DATA)
+    SAMPLE_RELATION_DATA["password_id"] = secret_id
+    harness.add_relation("smtp", "smtp-provider", app_data=SAMPLE_RELATION_DATA)
     relation_data = harness.charm.smtp.get_relation_data()
     assert relation_data
-    assert relation_data.host == RELATION_DATA["host"]
-    assert relation_data.port == int(RELATION_DATA["port"])
-    assert relation_data.user == RELATION_DATA["user"]
-    assert relation_data.password_id == RELATION_DATA["password_id"]
+    assert relation_data.host == SAMPLE_RELATION_DATA["host"]
+    assert relation_data.port == int(SAMPLE_RELATION_DATA["port"])
+    assert relation_data.user == SAMPLE_RELATION_DATA["user"]
+    assert relation_data.password_id == SAMPLE_RELATION_DATA["password_id"]
     assert relation_data.password == password
-    assert relation_data.auth_type == RELATION_DATA["auth_type"]
-    assert relation_data.transport_security == RELATION_DATA["transport_security"]
-    assert relation_data.domain == RELATION_DATA["domain"]
-    assert relation_data.skip_ssl_verify == literal_eval(RELATION_DATA["skip_ssl_verify"])
+    assert relation_data.auth_type == SAMPLE_RELATION_DATA["auth_type"]
+    assert relation_data.transport_security == SAMPLE_RELATION_DATA["transport_security"]
+    assert relation_data.domain == SAMPLE_RELATION_DATA["domain"]
+    assert relation_data.skip_ssl_verify == literal_eval(SAMPLE_RELATION_DATA["skip_ssl_verify"])
 
 
 @pytest.mark.parametrize("is_leader", [True, False])

--- a/tests/unit/test_library_smtp.py
+++ b/tests/unit/test_library_smtp.py
@@ -52,6 +52,7 @@ SAMPLE_RELATION_DATA = {
     "skip_ssl_verify": "False",
 }
 
+
 class SmtpRequirerCharm(ops.CharmBase):
     """Class for requirer charm testing."""
 

--- a/tests/unit/test_library_smtp.py
+++ b/tests/unit/test_library_smtp.py
@@ -42,6 +42,7 @@ SAMPLE_LEGACY_RELATION_DATA = {
     **RELATION_DATA,
     "password": secrets.token_hex(),
 }
+
 SAMPLE_RELATION_DATA = {
     "host": "example.smtp",
     "port": "25",
@@ -245,12 +246,14 @@ def test_requirer_charm_with_valid_relation_data_emits_event(is_leader):
     harness = Harness(SmtpRequirerCharm, meta=REQUIRER_METADATA)
     harness.begin()
     harness.set_leader(is_leader)
+
     password = secrets.token_hex()
     secret_id = harness.add_user_secret({"password": password})
     harness.grant_secret(secret_id, "smtp-consumer")
     SAMPLE_RELATION_DATA["password_id"] = secret_id
     harness.add_relation("smtp", "smtp-provider", app_data=SAMPLE_RELATION_DATA)
     relation_data = harness.charm.smtp.get_relation_data()
+
     assert relation_data
     assert relation_data.host == SAMPLE_RELATION_DATA["host"]
     assert relation_data.port == int(SAMPLE_RELATION_DATA["port"])

--- a/tests/unit/test_library_smtp.py
+++ b/tests/unit/test_library_smtp.py
@@ -245,7 +245,7 @@ def test_requirer_charm_with_valid_relation_data_emits_event(is_leader):
     harness = Harness(SmtpRequirerCharm, meta=REQUIRER_METADATA)
     harness.begin()
     harness.set_leader(is_leader)
-    password = "secret"
+    password = secrets.token_hex()
     secret_id = harness.add_user_secret({"password": password})
     harness.grant_secret(secret_id, "smtp-consumer")
     SAMPLE_RELATION_DATA["password_id"] = secret_id


### PR DESCRIPTION

### Overview

Handle the secret password in the requirer instead of user charm.

### Rationale

The `smtp` integration uses secrets. It gives the secret id to the requirer charm and let it handle the secret resolving. Resolving secrets should be the libraries responsibility since it is a part of libraries implementation.
<!-- The reason the change is needed -->

### Library Changes

There are 2 relations this library supports:

- `smtp_legacy` is used with older Juju  versions where secrets are not supported.
- `smtp` supports secrets.

The `SmtpRequires._get_relation_data_from_relation()` function is used by the library to create the `SmtpRelationData` object from relation data. This object has 2 fields related to password:

- password
- password_id

If the charm uses `smtp` library the `password` field is left `None`. With the changes in this pr the `SmtpRequires._get_relation_data_from_relation()` function will populate this field with the secret contents.

All this secret resolution happens on the requirer charm. The actual relation data is not touched so the secrets are not leaked outside of the requirer charm.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
