### PR TITLE
Fix secret never granted if password set after relation established

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -92,7 +92,7 @@ class SmtpIntegratorOperatorCharm(ops.CharmBase):
                 del peer_relation.data[self.app][secret_id]
         if not secret:
             # https://github.com/canonical/operator/issues/2025
-            secret = self.app.add_secret({"palceholder": "placeholder"})
+            secret = self.app.add_secret({"placeholder": "placeholder"})
         if self._charm_state.password:
             secret.set_content({"password": self._charm_state.password})
             peer_relation.data[self.app].update({"secret-id": typing.cast(str, secret.id)})

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,7 +7,6 @@
 
 import logging
 import typing
-from typing import Optional
 
 import ops
 from charms.smtp_integrator.v0 import smtp


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Fixes #114 

### Rationale

<!-- The reason the change is needed -->
A grant is not executed on the secret when it is created once the relation already exists, so the easiest fix is to create the secret when a relation joins if it doens't exist already, grant and never delete it to simplify the management of its lifecycle.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`trivial`, `senior-review-required`, `documentation`)

<!-- Explanation for any unchecked items above -->
