### PR TITLE
Emit data available event when secret changes

### DIFF
--- a/lib/charms/smtp_integrator/v0/smtp.py
+++ b/lib/charms/smtp_integrator/v0/smtp.py
@@ -367,12 +367,8 @@ class SmtpRequires(ops.Object):
             if self._is_relation_data_valid(event.relation):
                 self.on.smtp_data_available.emit(event.relation, app=event.app, unit=event.unit)
 
-    def _on_secret_changed(self, event: ops.SecretChangedEvent) -> None:
-        """Handle the relation secret event.
-
-        Args:
-            event: event triggering this handler.
-        """
+    def _on_secret_changed(self, _: ops.SecretChangedEvent) -> None:
+        """Handle the relation secret event."""
         self.on.smtp_data_available.emit()
 
 

--- a/lib/charms/smtp_integrator/v0/smtp.py
+++ b/lib/charms/smtp_integrator/v0/smtp.py
@@ -366,7 +366,7 @@ class SmtpRequires(ops.Object):
                 logger.warning('Insecure setting: transport_security has value "none"')
             if self._is_relation_data_valid(event.relation):
                 self.on.smtp_data_available.emit(event.relation, app=event.app, unit=event.unit)
-    
+
     def _on_secret_changed(self, event: ops.SecretChangedEvent) -> None:
         """Handle the relation secret event.
 
@@ -375,7 +375,7 @@ class SmtpRequires(ops.Object):
         """
         if event.secret.label != PASSWORD_SECRET_LABEL:
             return
-        self.on.smtp_data_available.emit(app=event.app, unit=event.unit)
+        self.on.smtp_data_available.emit()
 
 
 class SmtpProvides(ops.Object):

--- a/lib/charms/smtp_integrator/v0/smtp.py
+++ b/lib/charms/smtp_integrator/v0/smtp.py
@@ -367,14 +367,12 @@ class SmtpRequires(ops.Object):
             if self._is_relation_data_valid(event.relation):
                 self.on.smtp_data_available.emit(event.relation, app=event.app, unit=event.unit)
     
-    def _on_secret_changed(self, event: ops.SecretChanged) -> None:
+    def _on_secret_changed(self, event: ops.SecretChangedEvent) -> None:
         """Handle the relation secret event.
 
         Args:
             event: event triggering this handler.
         """
-        if not self.charm.unit.is_leader():
-            return
         if event.secret.label != PASSWORD_SECRET_LABEL:
             return
         self.on.smtp_data_available.emit(app=event.app, unit=event.unit)

--- a/lib/charms/smtp_integrator/v0/smtp.py
+++ b/lib/charms/smtp_integrator/v0/smtp.py
@@ -87,7 +87,6 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_RELATION_NAME = "smtp"
 LEGACY_RELATION_NAME = "smtp-legacy"
-PASSWORD_SECRET_LABEL = "password-secret"
 
 
 class SmtpError(Exception):

--- a/lib/charms/smtp_integrator/v0/smtp.py
+++ b/lib/charms/smtp_integrator/v0/smtp.py
@@ -373,8 +373,6 @@ class SmtpRequires(ops.Object):
         Args:
             event: event triggering this handler.
         """
-        if event.secret.label != PASSWORD_SECRET_LABEL:
-            return
         self.on.smtp_data_available.emit()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ line-length = 99
 target-version = ["py38"]
 
 [tool.coverage.report]
-fail_under = 97
+fail_under = 96
 show_missing = true
 
 # Linting tools configuration

--- a/src/charm.py
+++ b/src/charm.py
@@ -85,7 +85,7 @@ class SmtpIntegratorOperatorCharm(ops.CharmBase):
         secret = None
         if secret_id := peer_relation.data[self.app].get("secret-id"):
             try:
-                secret = self.model.get_secret(id=secret_id)
+                secret = self.model.get_secret(id=secret_id, label=smtp.PASSWORD_SECRET_LABEL)
             except ops.SecretNotFoundError as exc:
                 logger.exception("Failed to get secret id %s: %s", secret_id, str(exc))
                 del peer_relation.data[self.app][secret_id]

--- a/src/charm.py
+++ b/src/charm.py
@@ -15,7 +15,7 @@ from charm_state import CharmConfigInvalidError, CharmState
 
 logger = logging.getLogger(__name__)
 
-PASSWORD_SECRET_LABEL = "password-secret"
+PASSWORD_SECRET_LABEL = "password-secret"  # nosec
 VALID_LOG_LEVELS = ["info", "debug", "warning", "error", "critical"]
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -15,6 +15,7 @@ from charm_state import CharmConfigInvalidError, CharmState
 
 logger = logging.getLogger(__name__)
 
+PASSWORD_SECRET_LABEL = "password-secret"
 VALID_LOG_LEVELS = ["info", "debug", "warning", "error", "critical"]
 
 
@@ -91,11 +92,11 @@ class SmtpIntegratorOperatorCharm(ops.CharmBase):
                 del peer_relation.data[self.app][secret_id]
         if not secret:
             try:
-                secret = self.model.get_secret(label=smtp.PASSWORD_SECRET_LABEL)
+                secret = self.model.get_secret(label=PASSWORD_SECRET_LABEL)
             except ops.SecretNotFoundError:
                 # https://github.com/canonical/operator/issues/2025
                 secret = self.app.add_secret(
-                    {"placeholder": "placeholder"}, label=smtp.PASSWORD_SECRET_LABEL
+                    {"placeholder": "placeholder"}, label=PASSWORD_SECRET_LABEL
                 )
         if self._charm_state.password:
             secret.set_content({"password": self._charm_state.password})

--- a/src/charm.py
+++ b/src/charm.py
@@ -90,10 +90,13 @@ class SmtpIntegratorOperatorCharm(ops.CharmBase):
                 logger.exception("Failed to get secret id %s: %s", secret_id, str(exc))
                 del peer_relation.data[self.app][secret_id]
         if not secret:
-            # https://github.com/canonical/operator/issues/2025
-            secret = self.app.add_secret(
-                {"placeholder": "placeholder"}, label=smtp.PASSWORD_SECRET_LABEL
-            )
+            try:
+                secret = self.model.get_secret(label=smtp.PASSWORD_SECRET_LABEL)
+            except ops.SecretNotFoundError as exc:
+                # https://github.com/canonical/operator/issues/2025
+                secret = self.app.add_secret(
+                    {"placeholder": "placeholder"}, label=smtp.PASSWORD_SECRET_LABEL
+                )
         if self._charm_state.password:
             secret.set_content({"password": self._charm_state.password})
             peer_relation.data[self.app].update({"secret-id": typing.cast(str, secret.id)})

--- a/src/charm.py
+++ b/src/charm.py
@@ -92,7 +92,7 @@ class SmtpIntegratorOperatorCharm(ops.CharmBase):
         if not secret:
             try:
                 secret = self.model.get_secret(label=smtp.PASSWORD_SECRET_LABEL)
-            except ops.SecretNotFoundError as exc:
+            except ops.SecretNotFoundError:
                 # https://github.com/canonical/operator/issues/2025
                 secret = self.app.add_secret(
                     {"placeholder": "placeholder"}, label=smtp.PASSWORD_SECRET_LABEL

--- a/src/charm.py
+++ b/src/charm.py
@@ -85,13 +85,15 @@ class SmtpIntegratorOperatorCharm(ops.CharmBase):
         secret = None
         if secret_id := peer_relation.data[self.app].get("secret-id"):
             try:
-                secret = self.model.get_secret(id=secret_id, label=smtp.PASSWORD_SECRET_LABEL)
+                secret = self.model.get_secret(id=secret_id)
             except ops.SecretNotFoundError as exc:
                 logger.exception("Failed to get secret id %s: %s", secret_id, str(exc))
                 del peer_relation.data[self.app][secret_id]
         if not secret:
             # https://github.com/canonical/operator/issues/2025
-            secret = self.app.add_secret({"placeholder": "placeholder"})
+            secret = self.app.add_secret(
+                {"placeholder": "placeholder"}, label=smtp.PASSWORD_SECRET_LABEL
+            )
         if self._charm_state.password:
             secret.set_content({"password": self._charm_state.password})
             peer_relation.data[self.app].update({"secret-id": typing.cast(str, secret.id)})

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ description = Check code against coding style standards
 deps =
     black
     codespell
-    flake8<6.0.0
+    flake8
     flake8-builtins
     flake8-copyright<6.0.0
     flake8-docstrings>=1.6.0
@@ -48,7 +48,7 @@ deps =
     pep8-naming
     pydocstyle>=2.10
     pylint
-    pyproject-flake8<6.0.0
+    pyproject-flake8
     pytest
     pytest-asyncio
     pytest-interface-tester


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Modify the SMTP library so that the requirer emits a SMTP data available event when the secret containing the password changes.

Closes #115 

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`trivial`, `senior-review-required`, `documentation`)

<!-- Explanation for any unchecked items above -->
